### PR TITLE
feat: add gRPC and WebAPI hosting in single server

### DIFF
--- a/.github/workflows/grpc-build.yaml
+++ b/.github/workflows/grpc-build.yaml
@@ -32,7 +32,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ["GrpcAspNetCore60", "GrpcAspNetCore60.HealthCheckSupport"]
+        project:
+          [
+            "GrpcApiService",
+            "GrpcAspNetCore60",
+            "GrpcAspNetCore60.HealthCheckSupport",
+          ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -51,7 +56,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ["GrpcAspNetCore60", "GrpcAspNetCore60.HealthCheckSupport"]
+        project:
+          [
+            "GrpcApiService",
+            "GrpcAspNetCore60",
+            "GrpcAspNetCore60.HealthCheckSupport",
+          ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/Csharp-lab.sln
+++ b/Csharp-lab.sln
@@ -45,11 +45,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Logic", "Logic", "{0778B89C
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SourceGenerator", "SourceGenerator", "{01137DDA-726D-4ACF-B2D1-9363A369288D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicSourceGenerator", "src\SourceGenerator\BasicSourceGenerator\BasicSourceGenerator.csproj", "{0883FA56-3FA0-4165-B309-F6E3D6477355}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BasicSourceGenerator", "src\SourceGenerator\BasicSourceGenerator\BasicSourceGenerator.csproj", "{0883FA56-3FA0-4165-B309-F6E3D6477355}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Api", "Api", "{28CE7184-F1DE-44AE-922F-965FC3AA1768}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApiMultiplePort", "src\Api\ApiMultiplePort\ApiMultiplePort.csproj", "{CA7B2C05-D07A-47DE-8A03-523A38FA4BB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApiMultiplePort", "src\Api\ApiMultiplePort\ApiMultiplePort.csproj", "{CA7B2C05-D07A-47DE-8A03-523A38FA4BB2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GrpcApiService", "src\Grpc\GrpcApiService\GrpcApiService.csproj", "{A2DF5486-1CA6-4077-A96F-436D6014B88C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -125,6 +127,10 @@ Global
 		{CA7B2C05-D07A-47DE-8A03-523A38FA4BB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA7B2C05-D07A-47DE-8A03-523A38FA4BB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA7B2C05-D07A-47DE-8A03-523A38FA4BB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2DF5486-1CA6-4077-A96F-436D6014B88C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2DF5486-1CA6-4077-A96F-436D6014B88C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2DF5486-1CA6-4077-A96F-436D6014B88C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2DF5486-1CA6-4077-A96F-436D6014B88C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -147,6 +153,7 @@ Global
 		{E64765D4-FAA6-4599-85C9-664AFFC75C6C} = {A60DE0A8-D3F7-4BCF-B5C6-A59D03E99151}
 		{0883FA56-3FA0-4165-B309-F6E3D6477355} = {01137DDA-726D-4ACF-B2D1-9363A369288D}
 		{CA7B2C05-D07A-47DE-8A03-523A38FA4BB2} = {28CE7184-F1DE-44AE-922F-965FC3AA1768}
+		{A2DF5486-1CA6-4077-A96F-436D6014B88C} = {BA8C7910-6742-43BC-88A1-1D3644E1D783}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AD43C70-ADE6-43C4-A90D-F4E7CB0BD2F9}

--- a/src/Grpc/GrpcApiService/Controllers/HttpApiController.cs
+++ b/src/Grpc/GrpcApiService/Controllers/HttpApiController.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace GrpcApiService.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class HttpApiController : ControllerBase
+    {
+        private readonly ILogger<HttpApiController> _logger;
+
+        public HttpApiController(ILogger<HttpApiController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet(Name = "GetWeatherForecast")]
+        public string Get()
+        {
+            return "This is Http1 API.";
+        }
+    }
+}

--- a/src/Grpc/GrpcApiService/Dockerfile
+++ b/src/Grpc/GrpcApiService/Dockerfile
@@ -1,0 +1,21 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+WORKDIR /app
+EXPOSE 5094 5095
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["src/Grpc/GrpcApiService/GrpcApiService.csproj", "src/Grpc/GrpcApiService/"]
+RUN dotnet restore "src/Grpc/GrpcApiService/GrpcApiService.csproj"
+COPY . .
+WORKDIR "/src/src/Grpc/GrpcApiService"
+RUN dotnet build "GrpcApiService.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "GrpcApiService.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "GrpcApiService.dll"]

--- a/src/Grpc/GrpcApiService/GrpcApiService.csproj
+++ b/src/Grpc/GrpcApiService/GrpcApiService.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..\..</DockerfileContext>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,6 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
     <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.47.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/src/Grpc/GrpcApiService/GrpcApiService.csproj
+++ b/src/Grpc/GrpcApiService/GrpcApiService.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.40.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.47.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Grpc/GrpcApiService/Program.cs
+++ b/src/Grpc/GrpcApiService/Program.cs
@@ -1,0 +1,40 @@
+using GrpcApiService.Services;
+
+// $ curl -X 'GET' 'http://localhost:5094/HttpApi'
+// $ grpcurl --plaintext localhost:5095 list
+// $ grpcurl --plaintext -d "{\"name\":\"foo\"}" localhost:5095 greet.Greeter/SayHello
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Additional configuration is required to successfully run gRPC on macOS.
+// For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+
+// Add Web API Controller
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+// Add services to the container.
+builder.Services.AddGrpc();
+
+// Allow reflection for grpcurl
+builder.Services.AddGrpcReflection();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.MapGrpcReflectionService();
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseAuthorization();
+
+// Configure the HTTP request pipeline.
+app.MapGrpcService<GreeterService>(); // grpc
+app.MapControllers(); // api controller
+app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+
+app.Run();

--- a/src/Grpc/GrpcApiService/Properties/launchSettings.json
+++ b/src/Grpc/GrpcApiService/Properties/launchSettings.json
@@ -2,15 +2,24 @@
   "profiles": {
     "GrpcApiService": {
       "commandName": "Project",
-      "dotnetRunMessages": true,
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "http://localhost:5094;http://localhost:5095",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Kestrel__Endpoints__Grpc__Url": "http://localhost:5095",
         "Kestrel__Endpoints__webApi__Url": "http://localhost:5094"
-      }
+      },
+      "applicationUrl": "http://localhost:5094;http://localhost:5095",
+      "dotnetRunMessages": true
+    },
+    "Docker": {
+      "commandName": "Docker",
+      "launchBrowser": false,
+      "publishAllPorts": true,
+      "environmentVariables": {
+        "ASPNETCORE_URLS": "https://+:5094;http://+:5095"
+      },
+      "httpPort": 5095
     }
   }
 }

--- a/src/Grpc/GrpcApiService/Properties/launchSettings.json
+++ b/src/Grpc/GrpcApiService/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "GrpcApiService": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5094;http://localhost:5095",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Kestrel__Endpoints__Grpc__Url": "http://localhost:5095",
+        "Kestrel__Endpoints__webApi__Url": "http://localhost:5094"
+      }
+    }
+  }
+}

--- a/src/Grpc/GrpcApiService/Protos/greet.proto
+++ b/src/Grpc/GrpcApiService/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "GrpcApiService";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}

--- a/src/Grpc/GrpcApiService/Services/GreeterService.cs
+++ b/src/Grpc/GrpcApiService/Services/GreeterService.cs
@@ -1,0 +1,22 @@
+using Grpc.Core;
+using GrpcApiService;
+
+namespace GrpcApiService.Services
+{
+    public class GreeterService : Greeter.GreeterBase
+    {
+        private readonly ILogger<GreeterService> _logger;
+        public GreeterService(ILogger<GreeterService> logger)
+        {
+            _logger = logger;
+        }
+
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply
+            {
+                Message = "Hello " + request.Name
+            });
+        }
+    }
+}

--- a/src/Grpc/GrpcApiService/appsettings.Development.json
+++ b/src/Grpc/GrpcApiService/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Grpc/GrpcApiService/appsettings.json
+++ b/src/Grpc/GrpcApiService/appsettings.json
@@ -1,0 +1,24 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "Endpoints": {
+      "Grpc": {
+        "Protocols": "Http2",
+        "Url": "http://+:5095"
+      },
+      "webApi": {
+        "Protocols": "Http1",
+        "Url": "http://+:5094"
+      }
+    },
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}


### PR DESCRIPTION
## tl;dr;

This sample host gRPC (HTTP2 / tcp:5095) and WebAPI (HTTP1 / tcp:5094) in single startup.