### PR TITLE
feat: add Redis and StackExchangeRedisCache to adopt failover scenario

### DIFF
--- a/Csharp-lab.sln
+++ b/Csharp-lab.sln
@@ -136,7 +136,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "WhatsNew", "WhatsNew", "{D2
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharp10.Tests", "src\WhatsNew\CSharp10.Tests\CSharp10.Tests.csproj", "{F4E57CF9-A1E9-46D8-84CF-354C962377B5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharp6.Tests", "src\WhatsNew\CSharp6.Tests\CSharp6.Tests.csproj", "{6CA0D0AB-721D-401E-8592-8B2F81DF7B3B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharp6.Tests", "src\WhatsNew\CSharp6.Tests\CSharp6.Tests.csproj", "{6CA0D0AB-721D-401E-8592-8B2F81DF7B3B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RedisFailover", "src\Redis\RedisFailover\RedisFailover.csproj", "{473A75DE-21AD-4A1C-BF50-59D3D1D4D1E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RedisFailoverDirect", "src\Redis\RedisFailoverDirect\RedisFailoverDirect.csproj", "{BCD1E0A6-9E62-4B22-86FF-F1207313615A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -336,6 +340,14 @@ Global
 		{6CA0D0AB-721D-401E-8592-8B2F81DF7B3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CA0D0AB-721D-401E-8592-8B2F81DF7B3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CA0D0AB-721D-401E-8592-8B2F81DF7B3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{473A75DE-21AD-4A1C-BF50-59D3D1D4D1E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{473A75DE-21AD-4A1C-BF50-59D3D1D4D1E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{473A75DE-21AD-4A1C-BF50-59D3D1D4D1E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{473A75DE-21AD-4A1C-BF50-59D3D1D4D1E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BCD1E0A6-9E62-4B22-86FF-F1207313615A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BCD1E0A6-9E62-4B22-86FF-F1207313615A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BCD1E0A6-9E62-4B22-86FF-F1207313615A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BCD1E0A6-9E62-4B22-86FF-F1207313615A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -389,6 +401,8 @@ Global
 		{0CC5D10F-9792-4E95-9CB5-6244979D5A4A} = {F611191C-1089-4855-A8AA-ECE6F4586743}
 		{F4E57CF9-A1E9-46D8-84CF-354C962377B5} = {D2828C01-951E-4344-B225-DBCDB9502F6A}
 		{6CA0D0AB-721D-401E-8592-8B2F81DF7B3B} = {D2828C01-951E-4344-B225-DBCDB9502F6A}
+		{473A75DE-21AD-4A1C-BF50-59D3D1D4D1E2} = {3910F58C-6DEB-4C30-8B10-B9DA74B58225}
+		{BCD1E0A6-9E62-4B22-86FF-F1207313615A} = {3910F58C-6DEB-4C30-8B10-B9DA74B58225}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6AD43C70-ADE6-43C4-A90D-F4E7CB0BD2F9}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,11 +8,13 @@
     <PackageVersion Include="MemoryPack" Version="1.21.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.8" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="ZLogger" Version="2.5.5" />
     <!-- Benchmark -->
@@ -29,7 +31,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
     <!-- Redis -->
-    <PackageVersion Include="StackExchange.Redis" Version="2.8.0" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.8.12" />
     <!-- gRPC -->
     <PackageVersion Include="Google.Protobuf" Version="3.27.3" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.65.0" />

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,3 +1,5 @@
+# docker compose up
+# docker compose down --volumes
 services:
   mysql:
     image: bitnami/mysql:8.0
@@ -14,7 +16,7 @@ services:
       - mysql:/bitnami/mysql/data
 
   postgresql:
-    image: postgres:14.4
+    image: postgres:16.4
     ports:
       - 5432:5432
     environment:
@@ -24,6 +26,15 @@ services:
     volumes:
       - postgresql:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7.4
+    command: redis-server --save 60 1 --loglevel warning --requirepass password111
+    ports:
+      - 6379:6379
+    volumes:
+      - redis:/data
+
 volumes:
   mysql: {}
   postgresql: {}
+  redis: {}

--- a/src/Redis/RedisFailover/Dockerfile
+++ b/src/Redis/RedisFailover/Dockerfile
@@ -1,0 +1,29 @@
+# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+# This stage is used when running from VS in fast mode (Default for Debug configuration)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER app
+WORKDIR /app
+EXPOSE 8080
+
+
+# This stage is used to build the service project
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["src/Redis/RedisFailover/RedisFailover.csproj", "src/Redis/RedisFailover/"]
+RUN dotnet restore "./src/Redis/RedisFailover/RedisFailover.csproj"
+COPY . .
+WORKDIR "/src/src/Redis/RedisFailover"
+RUN dotnet build "./RedisFailover.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+# This stage is used to publish the service project to be copied to the final stage
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./RedisFailover.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "RedisFailover.dll"]

--- a/src/Redis/RedisFailover/Infrastructures/DistributedCacheExtensions.cs
+++ b/src/Redis/RedisFailover/Infrastructures/DistributedCacheExtensions.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Caching.Distributed;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RedisFailover.Infrastructures;
+
+public static class DistributedCacheExpiration
+{
+    public static DistributedCacheEntryOptions Short = new DistributedCacheEntryOptions()
+        .SetSlidingExpiration(TimeSpan.FromSeconds(5))
+        .SetAbsoluteExpiration(TimeSpan.FromSeconds(10));
+
+    public static DistributedCacheEntryOptions Medium = new DistributedCacheEntryOptions()
+        .SetSlidingExpiration(TimeSpan.FromMinutes(30))
+        .SetAbsoluteExpiration(TimeSpan.FromMinutes(60));
+
+    public static DistributedCacheEntryOptions Long = new DistributedCacheEntryOptions()
+        .SetSlidingExpiration(TimeSpan.FromDays(1))
+        .SetAbsoluteExpiration(TimeSpan.FromDays(7));
+}
+
+public static class DistributedCacheExtensions
+{
+    private static JsonSerializerOptions serializerOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+    private static DistributedCacheEntryOptions defaultOptions = DistributedCacheExpiration.Medium;
+
+    public static async Task SetAsync<T>(this IDistributedCache cache, string key, T value, CancellationToken ct = default)
+    {
+        await SetAsync(cache, key, value, defaultOptions, ct);
+    }
+
+    public static async Task SetAsync<T>(this IDistributedCache cache, string key, T value, DistributedCacheEntryOptions options, CancellationToken ct = default)
+    {
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value, serializerOptions));
+        await cache.SetAsync(key, bytes, options, ct);
+    }
+
+    public static async Task<(bool Success, T? Value)> TryGetValueAsync<T>(this IDistributedCache cache, string key, CancellationToken ct = default)
+    {
+        var val = await cache.GetAsync(key, ct);
+        if (val == null)
+        {
+            return (false, default);
+        }
+
+        var value = JsonSerializer.Deserialize<T>(val, serializerOptions);
+        return (true, value);
+    }
+
+    public static async Task<T?> GetOrSetAsync<T>(this IDistributedCache cache, string key, T value, DistributedCacheEntryOptions? options = null, CancellationToken ct = default)
+    {
+        options ??= defaultOptions;
+        var val = await cache.TryGetValueAsync<T>(key, ct);
+        if (val.Success)
+        {
+            return val.Value;
+        }
+
+        await cache.SetAsync<T>(key, value, options, ct);
+        return value;
+    }
+}

--- a/src/Redis/RedisFailover/Program.cs
+++ b/src/Redis/RedisFailover/Program.cs
@@ -1,0 +1,119 @@
+using Microsoft.Extensions.Caching.Distributed;
+using RedisFailover.Infrastructures;
+using StackExchange.Redis;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddStackExchangeRedisCache(options =>
+{
+    options.ConfigurationOptions = ConfigurationOptions.Parse(builder.Configuration.GetConnectionString("Redis")!);
+    // for failover
+    options.ConfigurationOptions.AbortOnConnectFail = false;
+    options.ConfigurationOptions.HeartbeatConsistencyChecks = true; // Set heratbeat to detect connection failure
+    options.ConfigurationOptions.HeartbeatInterval = TimeSpan.FromSeconds(3); // Server shutdown delay duration this interval
+    options.ConfigurationOptions.AllowAdmin = true; // follow to Redis Cluster topoligy change by failover
+    options.InstanceName = "Redis";
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast")
+.WithOpenApi();
+
+app.MapPost("/cache/long_operation", async (string key, TimeProvider timeProvider, IDistributedCache cache, CancellationToken ct) =>
+{
+    var ts = timeProvider.GetTimestamp();
+    DateTimeOffset value = timeProvider.GetLocalNow();
+    while (timeProvider.GetElapsedTime(ts) < TimeSpan.FromMinutes(2))
+    {
+        try
+        {
+            value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), DistributedCacheExpiration.Medium, ct);
+            app.Logger.LogInformation($"Redis operation success. {value}");
+        }
+        catch (RedisConnectionException ex)
+        {
+            app.Logger.LogError(ex, ex.Message);
+        }
+        finally
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+    }
+    return Results.Ok(value);
+})
+.WithName("LongCacheOperation")
+.WithOpenApi();
+
+app.MapPost("/cacheX", async (string key, TimeProvider timeProvider, IDistributedCache cache) =>
+{
+    var value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), DistributedCacheExpiration.Medium);
+    return Results.Ok(value);
+})
+.WithName("SetCacheX")
+.WithOpenApi();
+
+app.MapGet("/cache/{key}", async (string key, IDistributedCache cache, CancellationToken ct) =>
+{
+    var result = await cache.TryGetValueAsync<DateTimeOffset>(key, ct);
+    return result.Success
+        ? Results.Ok(result.Value)
+        : Results.NotFound();
+})
+.WithName("GetCache")
+.WithOpenApi();
+
+app.MapPost("/cache", async (string key, TimeProvider timeProvider, IDistributedCache cache) =>
+{
+    await cache.SetAsync(key, timeProvider.GetLocalNow(), DistributedCacheExpiration.Short);
+    return Results.Ok();
+})
+.WithName("SetCache")
+.WithOpenApi();
+
+app.MapDelete("/cache/{key}", async (string key, IDistributedCache cache) =>
+{
+    await cache.RemoveAsync(key);
+    return Results.Ok();
+})
+.WithName("DeleteCache")
+.WithOpenApi();
+
+app.Run();
+
+internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/src/Redis/RedisFailover/Properties/launchSettings.json
+++ b/src/Redis/RedisFailover/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ConnectionStrings__Redis": "localhost:6379,ssl=false,keepAlive=60,password=password111"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5238"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_HTTP_PORTS": "8080",
+        "ConnectionStrings__Redis": "localhost:6379,ssl=false,keepAlive=60,password=password111"
+      },
+      "publishAllPorts": true,
+      "useSSL": false
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json"
+}

--- a/src/Redis/RedisFailover/RedisFailover.csproj
+++ b/src/Redis/RedisFailover/RedisFailover.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..\..</DockerfileContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
+
+</Project>

--- a/src/Redis/RedisFailover/RedisFailover.http
+++ b/src/Redis/RedisFailover/RedisFailover.http
@@ -1,0 +1,6 @@
+@RedisFailover_HostAddress = http://localhost:5238
+
+GET {{RedisFailover_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/Redis/RedisFailover/appsettings.Development.json
+++ b/src/Redis/RedisFailover/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Redis/RedisFailover/appsettings.json
+++ b/src/Redis/RedisFailover/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "Redis": "YOUR_CONNECTION_STRING_FOR_REDIS"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/Redis/RedisFailoverDirect/Dockerfile
+++ b/src/Redis/RedisFailoverDirect/Dockerfile
@@ -1,0 +1,29 @@
+# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+# This stage is used when running from VS in fast mode (Default for Debug configuration)
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+USER app
+WORKDIR /app
+EXPOSE 8080
+
+
+# This stage is used to build the service project
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+COPY ["src/Redis/RedisFailoverDirect/RedisFailoverDirect.csproj", "src/Redis/RedisFailoverDirect/"]
+RUN dotnet restore "./src/Redis/RedisFailoverDirect/RedisFailoverDirect.csproj"
+COPY . .
+WORKDIR "/src/src/Redis/RedisFailoverDirect"
+RUN dotnet build "./RedisFailoverDirect.csproj" -c $BUILD_CONFIGURATION -o /app/build
+
+# This stage is used to publish the service project to be copied to the final stage
+FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
+RUN dotnet publish "./RedisFailoverDirect.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+
+# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "RedisFailoverDirect.dll"]

--- a/src/Redis/RedisFailoverDirect/ElastiCacheRouteHandler.cs
+++ b/src/Redis/RedisFailoverDirect/ElastiCacheRouteHandler.cs
@@ -1,0 +1,74 @@
+using RedisFailoverDirect.Infrastructures;
+using StackExchange.Redis;
+
+namespace RedisFailoverDirect;
+
+public static class ElastiCacheRouteHandler
+{
+    public static void AddElastiCacheRouteHandler(this WebApplication app)
+    {
+        app.MapPost("/cache/long_operation", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context, CancellationToken ct) =>
+        {
+            var ts = timeProvider.GetTimestamp();
+            DateTimeOffset value = timeProvider.GetLocalNow();
+            while (!ct.IsCancellationRequested && timeProvider.GetElapsedTime(ts) < TimeSpan.FromMinutes(10))
+            {
+                try
+                {
+                    var cache = context.GetDatabase();
+                    value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
+                    app.Logger.LogInformation($"Cache Redis operation success. {value}");
+                }
+                catch (RedisConnectionException ex)
+                {
+                    app.Logger.LogError(ex, ex.Message);
+                }
+                finally
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+            return Results.Ok(value);
+        })
+        .WithName("LongCacheOperation")
+        .WithOpenApi();
+
+        app.MapPost("/cacheX", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            var value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
+            return Results.Ok(value);
+        })
+        .WithName("SetCacheX")
+        .WithOpenApi();
+
+        app.MapGet("/cache/{key}", async (string key, ElastiCacheConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            var result = await cache.TryGetValueAsync<DateTimeOffset>(key);
+            return result.Success
+                ? Results.Ok(result.Value)
+                : Results.NotFound();
+        })
+        .WithName("GetCache")
+        .WithOpenApi();
+
+        app.MapPost("/cache", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            await cache.SetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Short);
+            return Results.Ok();
+        })
+        .WithName("SetCache")
+        .WithOpenApi();
+
+        app.MapDelete("/cache/{key}", async (string key, ElastiCacheConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            await cache.RemoveAsync(key);
+            return Results.Ok();
+        })
+        .WithName("DeleteCache")
+        .WithOpenApi();
+    }
+}

--- a/src/Redis/RedisFailoverDirect/Infrastructures/ConnectionMultiplexerExtensions.cs
+++ b/src/Redis/RedisFailoverDirect/Infrastructures/ConnectionMultiplexerExtensions.cs
@@ -1,0 +1,66 @@
+using StackExchange.Redis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace RedisFailoverDirect.Infrastructures;
+
+public static class RedisExpiry
+{
+    public static TimeSpan Short = TimeSpan.FromSeconds(10);
+
+    public static TimeSpan Medium = TimeSpan.FromMinutes(60);
+
+    public static TimeSpan Long = TimeSpan.FromDays(7);
+}
+
+public static class ConnectionMultiplexerExtensions
+{
+    private static JsonSerializerOptions serializerOptions = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+    private static TimeSpan defaultExpiry = RedisExpiry.Medium;
+
+    public static async Task SetAsync<T>(this IDatabase cache, string key, T value, When when = When.Always)
+    {
+        await SetAsync(cache, key, value, defaultExpiry, when);
+    }
+
+    public static async Task SetAsync<T>(this IDatabase cache, string key, T value, TimeSpan expiry, When when = When.Always)
+    {
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(value, serializerOptions));
+        await cache.StringSetAsync(key, bytes, expiry, when);
+    }
+
+    public static async Task<(bool Success, T? Value)> TryGetValueAsync<T>(this IDatabase cache, string key)
+    {
+        var val = await cache.StringGetAsync(key);
+        if (!val.HasValue)
+        {
+            return (false, default);
+        }
+
+        var value = JsonSerializer.Deserialize<T>(val.ToString(), serializerOptions);
+        return (true, value);
+    }
+
+    public static async Task<T?> GetOrSetAsync<T>(this IDatabase cache, string key, T value, TimeSpan expiry, When when = When.Always)
+    {
+        var val = await cache.TryGetValueAsync<T>(key);
+        if (val.Success)
+        {
+            return val.Value;
+        }
+
+        await cache.SetAsync<T>(key, value, expiry, when);
+        return value;
+    }
+
+    public static async Task RemoveAsync(this IDatabase cache, string key)
+    {
+        await cache.KeyDeleteAsync(key);
+    }
+}

--- a/src/Redis/RedisFailoverDirect/Infrastructures/RedisConnectionContext.cs
+++ b/src/Redis/RedisFailoverDirect/Infrastructures/RedisConnectionContext.cs
@@ -1,0 +1,112 @@
+using StackExchange.Redis;
+
+namespace RedisFailoverDirect.Infrastructures;
+
+public class ElastiCacheConnectionContext : RedisConnectionContext
+{
+    public ElastiCacheConnectionContext(string redisConnectionString, ILogger<RedisConnectionContext> logger)
+        : base("ElastiCache", redisConnectionString, logger)
+    {
+    }
+}
+public class MemoryDBConnectionContext : RedisConnectionContext
+{
+    public MemoryDBConnectionContext(string redisConnectionString, ILogger<RedisConnectionContext> logger)
+        : base("MemoryDB", redisConnectionString, logger)
+    {
+    }
+}
+public class RedisConnectionContext
+{
+    private readonly string _connectionString;
+    private Lazy<IConnectionMultiplexer> _lazyConnection; // Singleton pattern for ConnectionMultiplexer
+
+    private readonly ILogger<RedisConnectionContext> _logger;
+    private readonly object _lock = new object();
+    private int _failedConnectionAttempts = 0;
+    private const int MaxFailedConnectionAttempts = 999; // Threshold to regenerate the connection
+
+    public string Name { get; }
+
+    public RedisConnectionContext(string name, string connectionString, ILogger<RedisConnectionContext> logger)
+    {
+        Name = name;
+        _connectionString = connectionString;
+        _logger = logger;
+        _lazyConnection = new Lazy<IConnectionMultiplexer>(() => CreateConnection());
+    }
+
+    /// <summary>
+    /// Get the singleton connection instance
+    /// </summary>
+    private IConnectionMultiplexer Connection => _lazyConnection.Value;
+
+    /// <summary>
+    /// Method to get the Redis database instance
+    /// </summary>
+    /// <returns></returns>
+    public IDatabase GetDatabase()
+    {
+        return Connection.GetDatabase();
+    }
+
+    /// <summary>
+    /// Create new Redis connection
+    /// </summary>
+    /// <returns></returns>
+    private IConnectionMultiplexer CreateConnection()
+    {
+        var configurationOptions = ConfigurationOptions.Parse(_connectionString);
+        // for failover
+        configurationOptions.AbortOnConnectFail = false; // Reconnect when Redis cannot connect
+        configurationOptions.ReconnectRetryPolicy = new ExponentialRetry(5000); // try reconnect every 5sec
+        configurationOptions.HeartbeatConsistencyChecks = true; // Set heratbeat to detect connection failure
+        configurationOptions.HeartbeatInterval = TimeSpan.FromSeconds(3); // Server shutdown delay duration this interval
+        configurationOptions.AllowAdmin = true; // follow to Redis Cluster topoligy change by failover
+
+        _logger.LogInformation($"Connecting to redis: {Name}/{string.Join(",", configurationOptions.EndPoints)}");
+        var connection = ConnectionMultiplexer.Connect(configurationOptions);
+
+        connection.ConnectionFailed += (sender, args) => OnConnectionFailed(args);
+        connection.ConnectionRestored += (sender, args) => OnConnectionRestored(args);
+
+        _failedConnectionAttempts = 0; // Reset failed attempts after successful connection
+
+        return connection;
+    }
+
+    /// <summary>
+    /// Conneciton failure callback. Recreate IConnectionMultiplexer when it's internal state may broken because of Failover or any reason
+    /// </summary>
+    /// <param name="args"></param>
+    private void OnConnectionFailed(ConnectionFailedEventArgs args)
+    {
+        Console.WriteLine($"Redis connection failed to {args.EndPoint}: {args.FailureType}. Exception: {args.Exception?.Message}");
+        Interlocked.Increment(ref _failedConnectionAttempts); // Increment failed connection attempts
+
+        // If the number of failed attempts exceeds the threshold, recreate the connection
+        if (_failedConnectionAttempts >= MaxFailedConnectionAttempts)
+        {
+            lock (_lock)
+            {
+                // Ensure only one thread regenerates the connection
+                if (_lazyConnection!.IsValueCreated)
+                {
+                    Console.WriteLine($"Recreating Redis connection after multiple failures {Name}: {args.EndPoint}");
+                    _lazyConnection.Value.Dispose(); // Dispose of the existing connection
+                    _lazyConnection = new Lazy<IConnectionMultiplexer>(() => CreateConnection()); // Recreate the connection
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Connection restore callback. Reset failed attemp count because it's completed.
+    /// </summary>
+    /// <param name="args"></param>
+    private void OnConnectionRestored(ConnectionFailedEventArgs args)
+    {
+        Console.WriteLine($"Redis connection restored {Name}: {args.EndPoint}.");
+        _failedConnectionAttempts = 0; // Reset the counter on successful reconnection
+    }
+}

--- a/src/Redis/RedisFailoverDirect/Infrastructures/RedisConnectionContextExtentions.cs
+++ b/src/Redis/RedisFailoverDirect/Infrastructures/RedisConnectionContextExtentions.cs
@@ -1,0 +1,22 @@
+namespace RedisFailoverDirect.Infrastructures;
+
+public static class RedisConnectionContextExtentions
+{
+    public static IServiceCollection AddRedisCache(this IServiceCollection services)
+    {
+        services.AddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<RedisConnectionContext>>();
+            var connectionString = sp.GetRequiredService<IConfiguration>().GetConnectionString("Redis1");
+            return new ElastiCacheConnectionContext(connectionString!, logger);
+        });
+        services.AddSingleton(sp =>
+        {
+            var logger = sp.GetRequiredService<ILogger<RedisConnectionContext>>();
+            var connectionString = sp.GetRequiredService<IConfiguration>().GetConnectionString("Redis2");
+            return new MemoryDBConnectionContext(connectionString!, logger);
+        });
+
+        return services;
+    }
+}

--- a/src/Redis/RedisFailoverDirect/MemoryDBRouteHandler.cs
+++ b/src/Redis/RedisFailoverDirect/MemoryDBRouteHandler.cs
@@ -1,0 +1,74 @@
+using RedisFailoverDirect.Infrastructures;
+using StackExchange.Redis;
+
+namespace RedisFailoverDirect;
+
+public static class MemoryDBRouteHandler
+{
+    public static void AddMemoryDBRouteHandler(this WebApplication app)
+    {
+        app.MapPost("/persistent/long_operation", async (string key, TimeProvider timeProvider, MemoryDBConnectionContext context, CancellationToken ct) =>
+        {
+            var ts = timeProvider.GetTimestamp();
+            DateTimeOffset value = timeProvider.GetLocalNow();
+            while (!ct.IsCancellationRequested && timeProvider.GetElapsedTime(ts) < TimeSpan.FromMinutes(10))
+            {
+                try
+                {
+                    var cache = context.GetDatabase();
+                    value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
+                    app.Logger.LogInformation($"Persistent Redis operation success. {value}");
+                }
+                catch (RedisConnectionException ex)
+                {
+                    app.Logger.LogError(ex, ex.Message);
+                }
+                finally
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(1));
+                }
+            }
+            return Results.Ok(value);
+        })
+        .WithName("LongPersistentOperation")
+        .WithOpenApi();
+
+        app.MapPost("/persistentX", async (string key, TimeProvider timeProvider, MemoryDBConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            var value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
+            return Results.Ok(value);
+        })
+        .WithName("SetPersistentX")
+        .WithOpenApi();
+
+        app.MapGet("/persistent/{key}", async (string key, MemoryDBConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            var result = await cache.TryGetValueAsync<DateTimeOffset>(key);
+            return result.Success
+                ? Results.Ok(result.Value)
+                : Results.NotFound();
+        })
+        .WithName("GetPersistent")
+        .WithOpenApi();
+
+        app.MapPost("/persistent", async (string key, TimeProvider timeProvider, MemoryDBConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            await cache.SetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Short);
+            return Results.Ok();
+        })
+        .WithName("SetPersistent")
+        .WithOpenApi();
+
+        app.MapDelete("/persistent/{key}", async (string key, MemoryDBConnectionContext context) =>
+        {
+            var cache = context.GetDatabase();
+            await cache.RemoveAsync(key);
+            return Results.Ok();
+        })
+        .WithName("DeletePersistent")
+        .WithOpenApi();
+    }
+}

--- a/src/Redis/RedisFailoverDirect/Program.cs
+++ b/src/Redis/RedisFailoverDirect/Program.cs
@@ -1,0 +1,114 @@
+using RedisFailoverDirect.Infrastructures;
+using StackExchange.Redis;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
+
+// Add services to the container.
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddRedisCache();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+})
+.WithName("GetWeatherForecast")
+.WithOpenApi();
+
+app.MapPost("/cache/long_operation", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
+{
+    var ts = timeProvider.GetTimestamp();
+    DateTimeOffset value = timeProvider.GetLocalNow();
+    while (timeProvider.GetElapsedTime(ts) < TimeSpan.FromMinutes(2))
+    {
+        try
+        {
+            var cache = context.GetDatabase();
+            value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
+            app.Logger.LogInformation($"Redis operation success. {value}");
+        }
+        catch (RedisConnectionException ex)
+        {
+            app.Logger.LogError(ex, ex.Message);
+        }
+        finally
+        {
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+    }
+    return Results.Ok(value);
+})
+.WithName("LongCacheOperation")
+.WithOpenApi();
+
+app.MapPost("/cacheX", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
+{
+    var cache = context.GetDatabase();
+    var value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
+    return Results.Ok(value);
+})
+.WithName("SetCacheX")
+.WithOpenApi();
+
+app.MapGet("/cache/{key}", async (string key, ElastiCacheConnectionContext context) =>
+{
+    var cache = context.GetDatabase();
+    var result = await cache.TryGetValueAsync<DateTimeOffset>(key);
+    return result.Success
+        ? Results.Ok(result.Value)
+        : Results.NotFound();
+})
+.WithName("GetCache")
+.WithOpenApi();
+
+app.MapPost("/cache", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
+{
+    var cache = context.GetDatabase();
+    await cache.SetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Short);
+    return Results.Ok();
+})
+.WithName("SetCache")
+.WithOpenApi();
+
+app.MapDelete("/cache/{key}", async (string key, ElastiCacheConnectionContext context) =>
+{
+    var cache = context.GetDatabase();
+    await cache.RemoveAsync(key);
+    return Results.Ok();
+})
+.WithName("DeleteCache")
+.WithOpenApi();
+
+app.Run();
+
+internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/src/Redis/RedisFailoverDirect/Program.cs
+++ b/src/Redis/RedisFailoverDirect/Program.cs
@@ -1,5 +1,5 @@
+using RedisFailoverDirect;
 using RedisFailoverDirect.Infrastructures;
-using StackExchange.Redis;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -42,69 +42,8 @@ app.MapGet("/weatherforecast", () =>
 .WithName("GetWeatherForecast")
 .WithOpenApi();
 
-app.MapPost("/cache/long_operation", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
-{
-    var ts = timeProvider.GetTimestamp();
-    DateTimeOffset value = timeProvider.GetLocalNow();
-    while (timeProvider.GetElapsedTime(ts) < TimeSpan.FromMinutes(2))
-    {
-        try
-        {
-            var cache = context.GetDatabase();
-            value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
-            app.Logger.LogInformation($"Redis operation success. {value}");
-        }
-        catch (RedisConnectionException ex)
-        {
-            app.Logger.LogError(ex, ex.Message);
-        }
-        finally
-        {
-            await Task.Delay(TimeSpan.FromSeconds(1));
-        }
-    }
-    return Results.Ok(value);
-})
-.WithName("LongCacheOperation")
-.WithOpenApi();
-
-app.MapPost("/cacheX", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
-{
-    var cache = context.GetDatabase();
-    var value = await cache.GetOrSetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Medium);
-    return Results.Ok(value);
-})
-.WithName("SetCacheX")
-.WithOpenApi();
-
-app.MapGet("/cache/{key}", async (string key, ElastiCacheConnectionContext context) =>
-{
-    var cache = context.GetDatabase();
-    var result = await cache.TryGetValueAsync<DateTimeOffset>(key);
-    return result.Success
-        ? Results.Ok(result.Value)
-        : Results.NotFound();
-})
-.WithName("GetCache")
-.WithOpenApi();
-
-app.MapPost("/cache", async (string key, TimeProvider timeProvider, ElastiCacheConnectionContext context) =>
-{
-    var cache = context.GetDatabase();
-    await cache.SetAsync(key, timeProvider.GetLocalNow(), RedisExpiry.Short);
-    return Results.Ok();
-})
-.WithName("SetCache")
-.WithOpenApi();
-
-app.MapDelete("/cache/{key}", async (string key, ElastiCacheConnectionContext context) =>
-{
-    var cache = context.GetDatabase();
-    await cache.RemoveAsync(key);
-    return Results.Ok();
-})
-.WithName("DeleteCache")
-.WithOpenApi();
+app.AddElastiCacheRouteHandler();
+app.AddMemoryDBRouteHandler();
 
 app.Run();
 

--- a/src/Redis/RedisFailoverDirect/Properties/launchSettings.json
+++ b/src/Redis/RedisFailoverDirect/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ConnectionStrings__Redis1": "localhost:6379,ssl=false,keepAlive=60,password=password111",
+        "ConnectionStrings__Redis2": "localhost:6379,ssl=false,keepAlive=60,password=password111"
+      },
+      "dotnetRunMessages": true,
+      "applicationUrl": "http://localhost:5052"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker",
+      "launchBrowser": true,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_HTTP_PORTS": "8080",
+        "ConnectionStrings__Redis1": "localhost:6379,ssl=false,keepAlive=60,password=password111",
+        "ConnectionStrings__Redis2": "localhost:6379,ssl=false,keepAlive=60,password=password111"
+      },
+      "publishAllPorts": true,
+      "useSSL": false
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json"
+}

--- a/src/Redis/RedisFailoverDirect/RedisFailoverDirect.csproj
+++ b/src/Redis/RedisFailoverDirect/RedisFailoverDirect.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerfileContext>..\..\..</DockerfileContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="StackExchange.Redis" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+  </ItemGroup>
+
+</Project>

--- a/src/Redis/RedisFailoverDirect/RedisFailoverDirect.http
+++ b/src/Redis/RedisFailoverDirect/RedisFailoverDirect.http
@@ -1,0 +1,6 @@
+@RedisFailoverDirect_HostAddress = http://localhost:5052
+
+GET {{RedisFailoverDirect_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/Redis/RedisFailoverDirect/appsettings.Development.json
+++ b/src/Redis/RedisFailoverDirect/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Redis/RedisFailoverDirect/appsettings.json
+++ b/src/Redis/RedisFailoverDirect/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "ConnectionStrings": {
+    "Redis1": "YOUR_CONNECTION_STRING_FOR_REDIS",
+    "Redis2": "YOUR_CONNECTION_STRING_FOR_REDIS"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## tl;dr;

Add 2 project.

* RedisFailover: AddStackExchangeRedisCache pattern failover scenario. This pattern is for simple redis usage with `IDistributedCache`.
* RedisFailoverDirect: Manage StackExchange.Redis manually. This pattern is complex redis uage with `IConnectionMultiplexer`.

Both pattern handle failover and IConnectionMultiplexer recreation when redis connection is unstable.